### PR TITLE
Add universal wheel support

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -268,7 +268,7 @@ internationalized domain but ASCII local part, the returned dict is:
 
 Note that ``smtputf8`` is ``False`` even though the domain part is
 internationalized because
-`SMTPUTF8 <https://tools.ietf.org/html/rfc6531>`__ is only 
+`SMTPUTF8 <https://tools.ietf.org/html/rfc6531>`__ is only
 needed if the local part of the address is internationalized (the domain
 part can be converted to IDNA ASCII). Also note that the ``email`` and
 ``domain_i18n`` fields provide a normalized form of the email address
@@ -390,12 +390,13 @@ them through the validator (without deliverability checks) like so:
 For Project Maintainers
 -----------------------
 
-To publish a universal wheel to pypi::
+The package is distributed as a universal wheel. The wheel is specified as
+universal in the file ``setup.cfg`` by the ``universal = 1`` key in the
+``[bdist_wheel]`` section. To publish a universal wheel to pypi::
 
 	pip3 install twine
 	rm -rf dist
-	python3 setup.py bdist_wheel --universal
+	python3 setup.py bdist_wheel
 	twine upload dist/*
 	git tag v1.0.XXX
 	git push --tags
-	

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,0 +1,5 @@
+[bdist_wheel]
+universal = 1
+
+[metadata]
+license_file = LICENSE


### PR DESCRIPTION
Wheels are the new standard of python distribution.

For detailed information, see [PEP 427](https://www.python.org/dev/peps/pep-0427/).

For high level information, see: https://pythonwheels.com/

Advantages of wheels

* Faster installation for pure Python packages
* Avoids arbitrary code execution for installation (avoids setup.py)
* Allows better caching for testing and continuous integration
* Creates .pyc files as part of installation to ensure they match the python interpreter used
* More consistent installs across platforms and machines

As this package is pure Pythong (no C files), I have marked the wheel as universal.

when you'd normally run `python setup.py sdist upload`, run instead
`python setup.py sdist bdist_wheel upload`.