### PR TITLE
Add note to README.rst that UCS-4 support is required for Py2.7

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -188,6 +188,13 @@ ASCII <https://tools.ietf.org/html/rfc5891>`__. (You probably should not
 do this at account creation time so you don't change the user's login
 information without telling them.)
 
+UCS-4 support required for Python 2.7
+'''''''''''''''''''''''''''''''''''''
+
+Note that when using Python 2.7, it is required that it was built with 
+UCS-4 support (see `here <https://stackoverflow.com/questions/29109944/python-returns-length-of-2-for-single-unicode-character-string>`__); otherwise emails with unicode characters outside 
+of the BMP (Basic Multilingual Plane) will not validate correctly.
+
 Normalization
 -------------
 


### PR DESCRIPTION
This PR adds a clarifying comment to the README that Python 2.7 platforms with UCS-2 support only, e.g. the Python 2.7.13 installed with brew install python on my MacOS laptop, will not validate all internationalized emails correctly. E.g. the examples in lines 15-18 in `test_pass.txt` will fail. UCS-4 is required.

The reason is that the ATEXT_UTF8 regex will not match unicode chars outside of the BMP (Basic Multilingual Plane) on these platforms. Check if `len(u"\U0010FFFF")` evaluates to 2 (UCS-2) or 1 (UCS-4, or Python 3.3+). Python 3.3+ work fine.

See https://stackoverflow.com/questions/29109944/python-returns-length-of-2-for-single-unicode-character-string for a discussion.