### PR TITLE
Resolve email domain as unambiguous fully qualified domain name

### DIFF
--- a/email_validator/__init__.py
+++ b/email_validator/__init__.py
@@ -240,6 +240,9 @@ def validate_email_deliverability(domain, domain_i18n, timeout=DEFAULT_TIMEOUT):
 	# Check that the domain resolves to an MX record. If there is no MX record,
 	# try an A or AAAA record which is a deprecated fallback for deliverability.
 
+	# Add a trailing period to ensure the domain name is treated as fully qualified.
+	domain += '.'
+
 	try:
 		resolver = dns.resolver.get_default_resolver()
 


### PR DESCRIPTION
If dnspython receives a domain name that does not end in a period it may also try resolving it as not fully qualified. This can cause domains to be incorrectly resolved as if they exist.

This can be tested by adding a line `search mailinator.com` to `/etc/resolv.conf`. With that line added, the address `test@asdf.asdf` will be considered deliverable by email-validator.

The solution is to append a period to the domain before passing it to dnspython. This is valid because the domain part of the email address is not allowed to end in a period, and is required to be interpreted as fully qualified.