### PR TITLE
Enforce email address max length constraint.

### DIFF
--- a/email_validator/__init__.py
+++ b/email_validator/__init__.py
@@ -85,6 +85,11 @@ def validate_email(
     if len(parts) != 2:
         raise EmailSyntaxError("The email address is not valid. It must have exactly one @-sign.")
 
+    # RFC 5321 4.5.3.1.3 (we don't take into account the "<" and ">" delimiters)
+    # https://www.rfc-editor.org/errata_search.php?rfc=3696&eid=1690
+    if len(email) > 254:
+        raise EmailSyntaxError("The email address is too long.")
+
     # Prepare a dict to return on success.
     ret = {}
 

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -217,6 +217,7 @@ def test_email_valid(email_input, output):
          "The domain name ⒈wouldbeinvalid.com contains invalid characters (Codepoint U+2488 not allowed "
          "at position 1 in '⒈wouldbeinvalid.com')."),
         ('@example.com', 'There must be something before the @-sign.'),
+        ('{}@{}.com'.format(32 * 'x', '.'.join([60 * 'y' for _ in range(4)])), 'The email address is too long.'),
     ],
 )
 def test_email_invalid(email_input, error_msg):


### PR DESCRIPTION
Hi,

this should fix #35.

This PR checks the length of the whole address in the same way it's already been done with the localpart and the domain.

Nonetheless, I have the suspect that all three of these checks operates on the number of *characters*, while RFC 5321 explicitly demands that it is the number of *octects* that should be constrained (see the trailing part of https://tools.ietf.org/html/rfc5321#section-4.5.3.1).
As soon as the address includes UTF-8 characters the current checks might not work as expected.