### PR TITLE
Use end-of-string matcher instead of end-of-line matcher in regex

### DIFF
--- a/email_validator/__init__.py
+++ b/email_validator/__init__.py
@@ -128,7 +128,7 @@ def validate_email_local_part(local, allow_smtputf8=True, allow_empty_local=Fals
         raise EmailSyntaxError("The email address is too long before the @-sign.")
 
     # Check the local part against the regular expression for the older ASCII requirements.
-    m = re.match(DOT_ATOM_TEXT + "$", local)
+    m = re.match(DOT_ATOM_TEXT + "\\Z", local)
     if m:
         # Return the local part unchanged and flag that SMTPUTF8 is not needed.
         return {
@@ -138,7 +138,7 @@ def validate_email_local_part(local, allow_smtputf8=True, allow_empty_local=Fals
 
     else:
         # The local part failed the ASCII check. Now try the extended internationalized requirements.
-        m = re.match(DOT_ATOM_TEXT_UTF8 + "$", local)
+        m = re.match(DOT_ATOM_TEXT_UTF8 + "\\Z", local)
         if not m:
             # It's not a valid internationalized address either. Report which characters were not valid.
             bad_chars = ', '.join(sorted(set(
@@ -226,7 +226,7 @@ def validate_email_domain_part(domain):
 
     # Check the regular expression. This is probably entirely redundant
     # with idna.decode, which also checks this format.
-    m = re.match(DOT_ATOM_TEXT + "$", domain)
+    m = re.match(DOT_ATOM_TEXT + "\\Z", domain)
     if not m:
         raise EmailSyntaxError("The email address contains invalid characters after the @-sign.")
 
@@ -234,7 +234,7 @@ def validate_email_domain_part(domain):
     # one period. We also know that all TLDs end with a letter.
     if "." not in domain:
         raise EmailSyntaxError("The domain name %s is not valid. It should have a period." % domain_i18n)
-    if not re.search(r"[A-Za-z]$", domain):
+    if not re.search(r"[A-Za-z]\Z", domain):
         raise EmailSyntaxError(
             "The domain name %s is not valid. It is not within a valid top-level domain." % domain_i18n
         )

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -210,6 +210,12 @@ def test_email_valid(email_input, output):
          'The domain name baddash.-a.com contains invalid characters (Label must not start or end with a hyphen).'),
         ('my@baddash.b-.com',
          'The domain name baddash.b-.com contains invalid characters (Label must not start or end with a hyphen).'),
+        ('my@example.com\n',
+         'The domain name example.com\n contains invalid characters (Codepoint U+000A at position 4 of '
+         '\'com\\n\' not allowed).'),
+        ('my@example\n.com',
+         'The domain name example\n.com contains invalid characters (Codepoint U+000A at position 8 of '
+         '\'example\\n\' not allowed).'),
         ('.leadingdot@domain.com', 'The email address contains invalid characters before the @-sign: ..'),
         ('..twodots@domain.com', 'The email address contains invalid characters before the @-sign: ..'),
         ('twodots..here@domain.com', 'The email address contains invalid characters before the @-sign: ..'),
@@ -217,6 +223,9 @@ def test_email_valid(email_input, output):
          "The domain name ⒈wouldbeinvalid.com contains invalid characters (Codepoint U+2488 not allowed "
          "at position 1 in '⒈wouldbeinvalid.com')."),
         ('@example.com', 'There must be something before the @-sign.'),
+        ('\nmy@example.com', 'The email address contains invalid characters before the @-sign: \n.'),
+        ('m\ny@example.com', 'The email address contains invalid characters before the @-sign: \n.'),
+        ('my\n@example.com', 'The email address contains invalid characters before the @-sign: \n.'),
     ],
 )
 def test_email_invalid(email_input, error_msg):


### PR DESCRIPTION
Currently `$` is being appended to the regexes used to validate the local/domain parts in order to match the end of the line.  However, this allows emails like `hello\n@example.com` to appear valid, since `$` ignores the line termination character.  Using `\Z` instead of `$` resolves this problem.

This appears to only have caused a bug with the validation of the local part, since as stated in the comments the domain part regex validation is largely redundant with idna.decode, which also performs validation.