### PR TITLE
Refactor: Readability and deduplication

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -9,7 +9,7 @@ install:
 .PHONY: lint
 lint:
 	#python setup.py check -rms
-	flake8 --ignore=E501,E126 email_validator tests
+	flake8 --ignore=E501,E126,W503 email_validator tests
 
 .PHONY: test
 test:


### PR DESCRIPTION
Closes #47 by ensuring json dumps the dict representation of the class rather than the class itself.

Step by step changes:
1) W503 rule is [not pep8 compliant](https://www.python.org/dev/peps/pep-0008/#should-a-line-break-before-or-after-a-binary-operator) -- Pep8 guidelines say to break before a logical operator but W503 will yell if we do that. Let's just ignore it.
1) Simplifies the `ValidatedEmail.__eq__` functionality. Previously it was effectively: `if True: return True`, so let's just skip the if.
1) Instead of checking `if len(thing) - 254 != 1` we can simply check `if len(thing) != 255`. 
1) Centralize the version compatibility input shim. This dedupes the logic as well as provides an easier place to strip it out in the event of no longer maintaining py2 compatibility.
1) Stop defining hardcoded True values in `main` that are also the default params for the function being called.
1) Dump the dict representation of the class instead of the class itself, which doesn't serialize to json.

```
python-email-validator on  code_cleanup [?] via 🐍 3.8.4 took 6s 
➜ pipenv run email_validator dade@actualcrimes.org
{
  "ascii_domain": "actualcrimes.org",
  "ascii_email": "dade@actualcrimes.org",
  "ascii_local_part": "dade",
  "domain": "actualcrimes.org",
  "email": "dade@actualcrimes.org",
  "local_part": "dade",
  "mx": [
    [
      10,
      "helm.actualcrimes.org"
    ]
  ],
  "mx_fallback_type": null,
  "original_email": "dade@actualcrimes.org",
  "smtputf8": false
}
```