### PR TITLE
Fix: ValidatedEmail is not JSON serializable

### DIFF
--- a/email_validator/__init__.py
+++ b/email_validator/__init__.py
@@ -156,6 +156,10 @@ class ValidatedEmail(object):
                        ) \
             + ")"
 
+    """Convenience method for accessing ValidatedEmail as a dict"""
+    def as_dict(self):
+        return self.__dict__
+
 
 def validate_email(
     email,
@@ -536,7 +540,7 @@ def main():
             email = email.decode("utf8")  # assume utf8 in input
         try:
             result = validate_email(email, allow_smtputf8=allow_smtputf8, check_deliverability=check_deliverability)
-            print(json.dumps(result, indent=2, sort_keys=True, ensure_ascii=False))
+            print(json.dumps(result.as_dict(), indent=2, sort_keys=True, ensure_ascii=False))
         except EmailNotValidError as e:
             if sys.version_info < (3,):
                 print(unicode_class(e).encode("utf8"))

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -250,6 +250,13 @@ def test_email_invalid(email_input, error_msg):
     assert str(exc_info.value) == error_msg
 
 
+def test_dict_accessor():
+    input_email = "testaddr@example.com"
+    valid_email = validate_email(input_email, check_deliverability=False)
+    assert isinstance(valid_email.as_dict(), dict)
+    assert valid_email.as_dict()["original_email"] == input_email
+
+
 def test_deliverability_no_records():
     assert validate_email_deliverability('example.com', 'example.com') == {'mx': [(0, '')], 'mx-fallback': None}
 


### PR DESCRIPTION
Closes #47 by implementing a simple `as_dict()` method for `ValidatedEmail` that can be called when a dict serializable object is desired (such as dumping to json)