### PR TITLE
Simplify email equality check into return statement

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -9,7 +9,7 @@ install:
 .PHONY: lint
 lint:
 	#python setup.py check -rms
-	flake8 --ignore=E501,E126 email_validator tests
+	flake8 --ignore=E501,E126,W503 email_validator tests
 
 .PHONY: test
 test:

--- a/email_validator/__init__.py
+++ b/email_validator/__init__.py
@@ -135,14 +135,18 @@ class ValidatedEmail(object):
 
     """Tests use this."""
     def __eq__(self, other):
-        if self.email == other.email and self.local_part == other.local_part and self.domain == other.domain \
-           and self.ascii_email == other.ascii_email and self.ascii_local_part == other.ascii_local_part \
-           and self.ascii_domain == other.ascii_domain \
-           and self.smtputf8 == other.smtputf8 \
-           and repr(sorted(self.mx) if self.mx else self.mx) == repr(sorted(other.mx) if other.mx else other.mx) \
-           and self.mx_fallback_type == other.mx_fallback_type:
-            return True
-        return False
+        return (
+            self.email == other.email
+            and self.local_part == other.local_part
+            and self.domain == other.domain
+            and self.ascii_email == other.ascii_email
+            and self.ascii_local_part == other.ascii_local_part
+            and self.ascii_domain == other.ascii_domain
+            and self.smtputf8 == other.smtputf8
+            and repr(sorted(self.mx) if self.mx else self.mx)
+            == repr(sorted(other.mx) if other.mx else other.mx)
+            and self.mx_fallback_type == other.mx_fallback_type
+        )
 
     """This helps producing the README."""
     def as_constructor(self):


### PR DESCRIPTION
Since `ValidatedEmail.__eq__()`'s only behavior was to perform a long series of equality checks and return the result, we can simplify it to directly return the result of the equality checks, rather than wrapping it in an `if` statement to return `True` if `True`.

At the cost of increasing line count, it's now formatted with one equality check per line, making it easier to read. 

W503 rule is [not pep8 compliant](https://www.python.org/dev/peps/pep-0008/#should-a-line-break-before-or-after-a-binary-operator) -- Pep8 guidelines say to break before a logical operator but W503 will yell if we do that. Let's just ignore it.