### PR TITLE
Add possibility to cache dns lookups

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ Key features:
   login forms or other uses related to identifying users.
 * Gives friendly error messages when validation fails (appropriate to show
   to end users).
-* (optionally) Checks deliverability: Does the domain name resolve?
+* (optionally) Checks deliverability: Does the domain name resolve? And you can override the default DNS resolver.
 * Supports internationalized domain names and (optionally)
   internationalized local parts.
 * Normalizes email addresses (super important for internationalized
@@ -69,23 +69,27 @@ This validates the address and gives you its normalized form. You should
 put the normalized form in your database and always normalize before
 checking if an address is in your database.
 
-The validator will accept internationalized email addresses, but email
-addresses with non-ASCII characters in the *local* part of the address
-(before the @-sign) require the
-[SMTPUTF8](https://tools.ietf.org/html/rfc6531) extension which may not
-be supported by your mail submission library or your outbound mail
-server. If you know ahead of time that SMTPUTF8 is not supported then
-**add the keyword argument allow\_smtputf8=False to fail validation for
-addresses that would require SMTPUTF8**:
+When validating many email addresses or to control the timeout (the default is 15 seconds), create a caching [dns.resolver.Resolver](https://dnspython.readthedocs.io/en/latest/resolver-class.html) to reuse in each call:
 
 ```python
-valid = validate_email(email, allow_smtputf8=False)
+from email_validator import validate_email, caching_resolver
+
+resolver = caching_resolver(timeout=10)
+
+while True:
+  valid = validate_email(email, dns_resolver=resolver)
 ```
+
+The validator will accept internationalized email addresses, but not all
+mail systems can send email to an addresses with non-ASCII characters in
+the *local* part of the address (before the @-sign). See the `allow_smtputf8`
+option below.
+
 
 Overview
 --------
 
-The module provides a single function `validate_email(email_address)` which
+The module provides a function `validate_email(email_address)` which
 takes an email address (either a `str` or ASCII `bytes`) and:
 
 - Raises a `EmailNotValidError` with a helpful, human-readable error
@@ -129,21 +133,8 @@ shown):
 `allow_empty_local=False`: Set to `True` to allow an empty local part (i.e.
     `@example.com`), e.g. for validating Postfix aliases.
     
-`dns_resolver=None`: Set to an instance of dns.resolver.Resolver`
+`dns_resolver=None`: Pass an instance of [dns.resolver.Resolver](https://dnspython.readthedocs.io/en/latest/resolver-class.html) to control the DNS resolver including setting a timeout and [a cache](https://dnspython.readthedocs.io/en/latest/resolver-caching.html). The `caching_resolver` function shown above is a helper function to construct a dns.resolver.Resolver with a [LRUCache](https://dnspython.readthedocs.io/en/latest/resolver-caching.html#dns.resolver.LRUCache). Reuse the same resolver instance across calls to `validate_email` to make use of the cache.
 
-If you provide dns_resolver you can configure a cache and set resolver timeout. 
-When the resolver has a cache, successful dns lookups per domain will be cached 
-for subsequent calls.
-```python
-# New resolver automatically created (no dns caching)
-valid = validate_email(email)
-
-# DNS resover with caching and custom timeout used
-dns_resolver = dns.resolver.Resolver()
-dns_resolver.cache = dns.resolver.Cache()
-dns_resolver.timeout = 10
-valid = validate_email(email, dns_resolver=dns_resolver)
-```
 
 Internationalized email addresses
 ---------------------------------

--- a/README.md
+++ b/README.md
@@ -128,6 +128,22 @@ shown):
 
 `allow_empty_local=False`: Set to `True` to allow an empty local part (i.e.
     `@example.com`), e.g. for validating Postfix aliases.
+    
+`dns_resolver=None`: Set to an instance of dns.resolver.Resolver`
+
+If you provide dns_resolver you can configure a cache and set resolver timeout. 
+When the resolver has a cache, successful dns lookups per domain will be cached 
+for subsequent calls.
+```python
+# New resolver automatically created (no dns caching)
+valid = validate_email(email)
+
+# DNS resover with caching and custom timeout used
+dns_resolver = dns.resolver.Resolver()
+dns_resolver.cache = dns.resolver.Cache()
+dns_resolver.timeout = 10
+valid = validate_email(email, dns_resolver=dns_resolver)
+```
 
 Internationalized email addresses
 ---------------------------------

--- a/email_validator/__init__.py
+++ b/email_validator/__init__.py
@@ -186,6 +186,7 @@ def validate_email(
     allow_empty_local=False,
     check_deliverability=True,
     timeout=DEFAULT_TIMEOUT,
+    dns_resolver=None
 ):
     """
     Validates an email address, raising an EmailNotValidError if the address is not valid or returning a dict of
@@ -270,10 +271,16 @@ def validate_email(
             reason = "(when encoded in bytes)"
         raise EmailSyntaxError("The email address is too long {}.".format(reason))
 
+    if dns_resolver is None:
+        dns_resolver = dns.resolver.get_default_resolver()
+        dns_resolver.timeout = timeout
+
     if check_deliverability:
         # Validate the email address's deliverability and update the
         # return dict with metadata.
-        deliverability_info = validate_email_deliverability(ret["domain"], ret["domain_i18n"], timeout)
+        deliverability_info = validate_email_deliverability(
+            ret["domain"], ret["domain_i18n"], dns_resolver
+        )
         if "mx" in deliverability_info:
             ret.mx = deliverability_info["mx"]
             ret.mx_fallback_type = deliverability_info["mx-fallback"]
@@ -443,15 +450,15 @@ def validate_email_domain_part(domain):
     }
 
 
-def validate_email_deliverability(domain, domain_i18n, timeout=DEFAULT_TIMEOUT):
+def validate_email_deliverability(domain, domain_i18n, dns_resolver):
     # Check that the domain resolves to an MX record. If there is no MX record,
     # try an A or AAAA record which is a deprecated fallback for deliverability.
 
-    def dns_resolver_resolve_shim(resolver, domain, record):
+    def dns_resolver_resolve_shim(domain, record):
         try:
             # dns.resolver.Resolver.resolve is new to dnspython 2.x.
             # https://dnspython.readthedocs.io/en/latest/resolver-class.html#dns.resolver.Resolver.resolve
-            return resolver.resolve(domain, record)
+            return dns_resolver.resolve(domain, record)
         except AttributeError:
             # dnspython 2.x is only available in Python 3.6 and later. For earlier versions
             # of Python, we maintain compatibility with dnspython 1.x which has a
@@ -460,7 +467,7 @@ def validate_email_deliverability(domain, domain_i18n, timeout=DEFAULT_TIMEOUT):
             # which we prevent by adding a "." to the domain name to make it absolute.
             # dns.resolver.Resolver.query is deprecated in dnspython version 2.x.
             # https://dnspython.readthedocs.io/en/latest/resolver-class.html#dns.resolver.Resolver.query
-            return resolver.query(domain + ".", record)
+            return dns_resolver.query(domain + ".", record)
 
     try:
         # We need a way to check how timeouts are handled in the tests. So we
@@ -469,28 +476,23 @@ def validate_email_deliverability(domain, domain_i18n, timeout=DEFAULT_TIMEOUT):
         if getattr(validate_email_deliverability, 'TEST_CHECK_TIMEOUT', False):
             raise dns.exception.Timeout()
 
-        resolver = dns.resolver.get_default_resolver()
-
-        if timeout:
-            resolver.lifetime = timeout
-
         try:
             # Try resolving for MX records and get them in sorted priority order.
-            response = dns_resolver_resolve_shim(resolver, domain, "MX")
+            response = dns_resolver_resolve_shim(domain, "MX")
             mtas = sorted([(r.preference, str(r.exchange).rstrip('.')) for r in response])
             mx_fallback = None
         except (dns.resolver.NoNameservers, dns.resolver.NXDOMAIN, dns.resolver.NoAnswer):
 
             # If there was no MX record, fall back to an A record.
             try:
-                response = dns_resolver_resolve_shim(resolver, domain, "A")
+                response = dns_resolver_resolve_shim(domain, "A")
                 mtas = [(0, str(r)) for r in response]
                 mx_fallback = "A"
             except (dns.resolver.NoNameservers, dns.resolver.NXDOMAIN, dns.resolver.NoAnswer):
 
                 # If there was no A record, fall back to an AAAA record.
                 try:
-                    response = dns_resolver_resolve_shim(resolver, domain, "AAAA")
+                    response = dns_resolver_resolve_shim(domain, "AAAA")
                     mtas = [(0, str(r)) for r in response]
                     mx_fallback = "AAAA"
                 except (dns.resolver.NoNameservers, dns.resolver.NXDOMAIN, dns.resolver.NoAnswer):

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -3,7 +3,7 @@ import dns.resolver
 import pytest
 from email_validator import EmailSyntaxError, EmailUndeliverableError, \
                             validate_email, validate_email_deliverability, \
-                            ValidatedEmail
+                            caching_resolver, ValidatedEmail
 # Let's test main but rename it to be clear
 from email_validator import main as validator_main
 
@@ -262,19 +262,11 @@ def test_dict_accessor():
 
 
 def test_deliverability_no_records():
-    assert validate_email_deliverability(
-        'example.com',
-        'example.com',
-        dns_resolver=dns.resolver.get_default_resolver()
-    ) == {'mx': [(0, '')], 'mx-fallback': None}
+    assert validate_email_deliverability('example.com', 'example.com') == {'mx': [(0, '')], 'mx-fallback': None}
 
 
 def test_deliverability_found():
-    response = validate_email_deliverability(
-        'gmail.com',
-        'gmail.com',
-        dns_resolver=dns.resolver.get_default_resolver()
-    )
+    response = validate_email_deliverability('gmail.com', 'gmail.com')
     assert response.keys() == {'mx', 'mx-fallback'}
     assert response['mx-fallback'] is None
     assert len(response['mx']) > 1
@@ -286,16 +278,12 @@ def test_deliverability_found():
 def test_deliverability_fails():
     domain = 'xkxufoekjvjfjeodlfmdfjcu.com'
     with pytest.raises(EmailUndeliverableError, match='The domain name {} does not exist'.format(domain)):
-        validate_email_deliverability(domain, domain, dns_resolver=dns.resolver.get_default_resolver())
+        validate_email_deliverability(domain, domain)
 
 
 def test_deliverability_dns_timeout():
     validate_email_deliverability.TEST_CHECK_TIMEOUT = True
-    response = validate_email_deliverability(
-        'gmail.com',
-        'gmail.com',
-        dns_resolver=dns.resolver.get_default_resolver()
-    )
+    response = validate_email_deliverability('gmail.com', 'gmail.com')
     assert "mx" not in response
     assert response.get("unknown-deliverability") == "timeout"
     validate_email('test@gmail.com')
@@ -361,9 +349,20 @@ def test_main_output_shim(monkeypatch, capsys):
 
 
 @mock.patch("dns.resolver.LRUCache.put")
+def test_validate_email__with_caching_resolver(mocked_put):
+    dns_resolver = caching_resolver()
+    validate_email("test@gmail.com", dns_resolver=dns_resolver)
+    assert mocked_put.called
+
+    with mock.patch("dns.resolver.LRUCache.get") as mocked_get:
+        validate_email("test@gmail.com", dns_resolver=dns_resolver)
+        assert mocked_get.called
+
+
+@mock.patch("dns.resolver.LRUCache.put")
 def test_validate_email__with_configured_resolver(mocked_put):
     dns_resolver = dns.resolver.Resolver()
-    dns_resolver.timeout = 10
+    dns_resolver.lifetime = 10
     dns_resolver.cache = dns.resolver.LRUCache(max_size=1000)
     validate_email("test@gmail.com", dns_resolver=dns_resolver)
     assert mocked_put.called


### PR DESCRIPTION
Add optional argument dns_resolver to validate_email. If provided it will be used instead of the default resolver. The provided resolver can have a configured cache and custom timeout. Closes #55 

Example usage:
```python
dns_resolver = dns.resolver.Resolver()
dns_resolver.cache = dns.resolver.Cache()
dns_resolver.timeout = 10
valid = validate_email("test@gmail.com", dns_resolver=dns_resolver)
```