### PR TITLE
Fix bug in ValidatedEmail method __eq__()

### DIFF
--- a/email_validator/__init__.py
+++ b/email_validator/__init__.py
@@ -142,18 +142,20 @@ class ValidatedEmail(object):
 
     """Tests use this."""
     def __eq__(self, other):
-        return (
-            self.email == other.email
-            and self.local_part == other.local_part
-            and self.domain == other.domain
-            and self.ascii_email == other.ascii_email
-            and self.ascii_local_part == other.ascii_local_part
-            and self.ascii_domain == other.ascii_domain
-            and self.smtputf8 == other.smtputf8
-            and repr(sorted(self.mx) if self.mx else self.mx)
-            == repr(sorted(other.mx) if other.mx else other.mx)
-            and self.mx_fallback_type == other.mx_fallback_type
-        )
+        if isinstance(other, ValidatedEmail):
+            return (
+                self.email == other.email
+                and self.local_part == other.local_part
+                and self.domain == other.domain
+                and self.ascii_email == other.ascii_email
+                and self.ascii_local_part == other.ascii_local_part
+                and self.ascii_domain == other.ascii_domain
+                and self.smtputf8 == other.smtputf8
+                and repr(sorted(self.mx) if self.mx else self.mx)
+                == repr(sorted(other.mx) if other.mx else other.mx)
+                and self.mx_fallback_type == other.mx_fallback_type
+            )
+        return False
 
     """This helps producing the README."""
     def as_constructor(self):

--- a/email_validator/__init__.py
+++ b/email_validator/__init__.py
@@ -142,20 +142,20 @@ class ValidatedEmail(object):
 
     """Tests use this."""
     def __eq__(self, other):
-        if isinstance(other, ValidatedEmail):
-            return (
-                self.email == other.email
-                and self.local_part == other.local_part
-                and self.domain == other.domain
-                and self.ascii_email == other.ascii_email
-                and self.ascii_local_part == other.ascii_local_part
-                and self.ascii_domain == other.ascii_domain
-                and self.smtputf8 == other.smtputf8
-                and repr(sorted(self.mx) if self.mx else self.mx)
-                == repr(sorted(other.mx) if other.mx else other.mx)
-                and self.mx_fallback_type == other.mx_fallback_type
-            )
-        return False
+        if not isinstance(other, ValidatedEmail):
+            return False
+        return (
+            self.email == other.email
+            and self.local_part == other.local_part
+            and self.domain == other.domain
+            and self.ascii_email == other.ascii_email
+            and self.ascii_local_part == other.ascii_local_part
+            and self.ascii_domain == other.ascii_domain
+            and self.smtputf8 == other.smtputf8
+            and repr(sorted(self.mx) if self.mx else self.mx)
+             == repr(sorted(other.mx) if other.mx else other.mx)
+            and self.mx_fallback_type == other.mx_fallback_type
+        )
 
     """This helps producing the README."""
     def as_constructor(self):

--- a/email_validator/__init__.py
+++ b/email_validator/__init__.py
@@ -153,7 +153,7 @@ class ValidatedEmail(object):
             and self.ascii_domain == other.ascii_domain
             and self.smtputf8 == other.smtputf8
             and repr(sorted(self.mx) if self.mx else self.mx)
-             == repr(sorted(other.mx) if other.mx else other.mx)
+            == repr(sorted(other.mx) if other.mx else other.mx)
             and self.mx_fallback_type == other.mx_fallback_type
         )
 


### PR DESCRIPTION
There's a bug in method `__eq__()` of `ValidatedEmail`. It doesn't check whether `other` is an instance of type `ValidatedEmail`, so the following fails:

```
>>> from email_validator import validate_email
>>> v = validate_email('foo@test.com')
>>> v == "hello"
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/Users/yhassan/source/deferit/deferit/.env/lib/python3.8/site-packages/email_validator/__init__.py", line 146, in __eq__
    self.email == other.email
AttributeError: 'str' object has no attribute 'email'
```

Now checks parameter `other` is an instance of ValidatedEmail before checking all its members are equal to self's members.