### PR TITLE
Validation concessions options for top-level domains

### DIFF
--- a/README.md
+++ b/README.md
@@ -148,6 +148,11 @@ The `validate_email` function also accepts the following keyword arguments
 
 `test_environment=False`: DNS-based deliverability checks are disabled and  `test` and `subdomain.test` domain names are permitted (see below).
 
+`allow_special_domains=False`: Turning off EmailUndeliverableError exception for special top-level domains, such as "arpa", "local" and others. Default is False (restricted).
+
+`allow_any_top_level_domain=False`: Turn off EmailUndeliverableError exception for top-level domains, which are not matching with regex **[A-Za-z]\Z**, such as "org123". May be useful for local services in isolated environments with  special local TLD. Default is False (restricted).
+
+`allowed_top_level_domains=[]`: Similar with `allow_any_top_level_domain` but working like whitelist. Will be ignored, if  `allow_any_top_level_domain=True` or if list is empty. Default is [] (no allowed *bad* domains).
 ### DNS timeout and cache
 
 When validating many email addresses or to control the timeout (the default is 15 seconds), create a caching [dns.resolver.Resolver](https://dnspython.readthedocs.io/en/latest/resolver-class.html) to reuse in each call. The `caching_resolver` function returns one easily for you:

--- a/main.py
+++ b/main.py
@@ -1,0 +1,9 @@
+from email_validator import validate_email
+
+email1 = 'ewferfwekuh@ekjfjeir1.com'
+email2 = 'ewferfwekuh@ekjfjeir.ewrfref.mm71'
+email3 = 'ewferfwekuh@ekjfjeir.local'
+
+v1 = validate_email(email1,check_deliverability=False)
+v2 = validate_email(email2,check_deliverability=False,allow_any_top_level_domain=False,allowed_top_level_domains=['mm72','mm74'])
+v3 = validate_email(email3,check_deliverability=False,allow_special_domains=True)

--- a/main.py
+++ b/main.py
@@ -1,9 +1,0 @@
-from email_validator import validate_email
-
-email1 = 'ewferfwekuh@ekjfjeir1.com'
-email2 = 'ewferfwekuh@ekjfjeir.ewrfref.mm71'
-email3 = 'ewferfwekuh@ekjfjeir.local'
-
-v1 = validate_email(email1,check_deliverability=False)
-v2 = validate_email(email2,check_deliverability=False,allow_any_top_level_domain=False,allowed_top_level_domains=['mm72','mm74'])
-v3 = validate_email(email3,check_deliverability=False,allow_special_domains=True)

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1,0 +1,1 @@
+#Just for a right import from email_validator to the test_main.py on modern Python versions


### PR DESCRIPTION
Added some specific args for **validate_email** and  **validate_email_domain_part** methods to give an ability for validating "*bad*" TLD in email addresses. Full description was added in README

- `allow_special_domains=False` - ignore restrictions for SPECIAL_USE domains
- `allow_any_top_level_domain=False` - ignore regex constraints for a TLD
- `allowed_top_level_domains=[]` - whitelist for TLD, not matching regex from previous option

All tests passed

Default values were set such as `False` for saving the original validation logic without slowdown