### PR TITLE
Lazy load dns.resolver

### DIFF
--- a/email_validator/__init__.py
+++ b/email_validator/__init__.py
@@ -1,9 +1,16 @@
 # -*- coding: utf-8 -*-
 
 # Export the main method, helper methods, and the public data types.
-from .validate_email import validate_email  # noqa: F401
-from .deliverability import caching_resolver  # noqa: F401
 from .exceptions_types import *  # noqa: F401,F403
+from .validate_email import validate_email  # noqa: F401
+
+
+def caching_resolver(*args, **kwargs):
+    # Lazy load `deliverability` as it is slow to import (due to dns.resolver)
+    from .deliverability import caching_resolver
+
+    return caching_resolver(*args, **kwargs)
+
 
 # These global attributes are a part of the library's API and can be
 # changed by library users.

--- a/email_validator/validate_email.py
+++ b/email_validator/validate_email.py
@@ -1,6 +1,5 @@
 from .exceptions_types import EmailSyntaxError, ValidatedEmail
 from .syntax import validate_email_local_part, validate_email_domain_part, get_length_reason
-from .deliverability import validate_email_deliverability
 from .rfc_constants import EMAIL_MAX_LENGTH
 
 
@@ -115,6 +114,9 @@ def validate_email(
     if check_deliverability and not test_environment:
         # Validate the email address's deliverability using DNS
         # and update the return dict with metadata.
+
+        # Lazy load `deliverability` as it is slow to import (due to dns.resolver)
+        from .deliverability import validate_email_deliverability
         deliverability_info = validate_email_deliverability(
             ret["domain"], ret["domain_i18n"], timeout, dns_resolver
         )

--- a/setup.cfg
+++ b/setup.cfg
@@ -24,7 +24,7 @@ keywords = email address validator
 [options]
 packages = find:
 install_requires =
-    dnspython>=2.0.0
+    dnspython>=2.0.0 # optional if deliverability check isn't needed
     idna>=2.0.0
 python_requires = >=3.6
 


### PR DESCRIPTION
I usually `email_validator` through `pydantic` which doesn't check
deliverability.

The import of `email_validator` always trigger the import of
`dns.resolver` which will try to import `httpx`, `requests`, etc.
This import time can impact negatively the startup time of some apps.
I guess this is the reason why `email_validator` is already lazy loaded
in pydantic.

I propose here to postpone the import of `dns.resolver` to the first
time it is needed.

What do you think ?
