### PR TITLE
Replace deprecated `license_file` in `setup.cfg`

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -8,7 +8,7 @@ url = https://github.com/JoshData/python-email-validator
 author = Joshua Tauberer
 author_email = jt@occams.info
 license = CC0 (copyright waived)
-license_file = LICENSE
+license_files = LICENSE
 classifiers =
     Development Status :: 5 - Production/Stable
     Intended Audience :: Developers


### PR DESCRIPTION
Replace the deprecated option with `license_files`, to fix the following deprecation warning:

    /usr/lib/python3.11/site-packages/setuptools/config/setupcfg.py:515: SetuptoolsDeprecationWarning: The license_file parameter is deprecated, use license_files instead.

The new option is backwards compatible and is available since setuptools 42.0.0.