### PR TITLE
Include missing test files in sdist

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,2 +1,3 @@
 include email_validator.py
 include LICENSE README.md
+recursive-include tests *.json *.py


### PR DESCRIPTION
Include the missing `mocked_dns_response.py`
and `mocked-dns-answers.json` files in sdist archives, as they are necessary to run the test suite.