### PR TITLE
Fix entry point location

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -34,7 +34,7 @@ python_requires = >=3.7
 
 [options.entry_points]
 console_scripts =
-    email_validator=email_validator:main
+    email_validator=email_validator.__main__:main
 
 [flake8]
 max-line-length = 120


### PR DESCRIPTION
I'm finding that tests are failing on conda-forge:
https://github.com/conda-forge/email-validator-feedstock/pull/11
because the location of the entry point didn't get updated when `main()` got moved to `__main__.py`.  This PR should fix that.