### PR TITLE
Make dnspython package is optional

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,6 +47,12 @@ This package [is on PyPI](https://pypi.org/project/email-validator/), so:
 pip install email-validator
 ```
 
+If deliverability option will be used:
+
+```sh
+pip install email-validator[dns]
+```
+
 (You might need to use `pip3` depending on your local environment.)
 
 Quick Start

--- a/email_validator/deliverability.py
+++ b/email_validator/deliverability.py
@@ -2,8 +2,11 @@ from typing import Optional, Any, Dict
 
 from .exceptions_types import EmailUndeliverableError
 
-import dns.resolver
-import dns.exception
+try:
+    import dns.resolver
+    import dns.exception
+except ImportError as e:
+    raise ImportError('deliverability option requires dnspython, run `pip install email-validator[dns]`') from e
 
 
 def caching_resolver(*, timeout: Optional[int] = None, cache=None):

--- a/setup.cfg
+++ b/setup.cfg
@@ -25,9 +25,12 @@ keywords = email address validator
 [options]
 packages = find:
 install_requires =
-    dnspython>=2.0.0 # optional if deliverability check isn't needed
     idna>=2.0.0
 python_requires = >=3.7
+
+[options.extras_require]
+# optional if deliverability check isn't needed
+dns = dnspython>=2.0.0
 
 [options.package_data]
 * = py.typed


### PR DESCRIPTION
This PR make `dnspython` package optional, due to deliverability is optional as well. 

It reduces installed dependencies if we don't check `deliverability`.  Probably `CHECK_DELIVERABILITY` constant also should be changed to `False`, but it's change default behavior. 