### PR TITLE
Drop Python 3.7 from python_requires to fix 2.1.0 `SyntaxError`

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -27,7 +27,7 @@ packages = find:
 install_requires =
     dnspython>=2.0.0 # optional if deliverability check isn't needed
     idna>=2.0.0
-python_requires = >=3.7
+python_requires = >=3.8
 
 [options.package_data]
 * = py.typed


### PR DESCRIPTION
```
❯ conda activate py37
❯ python3
Python 3.7.16 (default, Jan 17 2023, 22:20:44) 
[GCC 11.2.0] :: Anaconda, Inc. on linux
Type "help", "copyright", "credits" or "license" for more information.
>>> exit
Use exit() or Ctrl-D (i.e. EOF) to exit
>>> exit()
❯ pip install email-validator
Looking in indexes: https://pypi.org/simple/, https://pypi.tuna.tsinghua.edu.cn/simple
WARNING: Retrying (Retry(total=4, connect=None, read=None, redirect=None, status=None)) after connection broken by 'ProtocolError('Connection aborted.', OSError(0, 'Error'))': /simple/email-validator/
Collecting email-validator
  Downloading https://pypi.tuna.tsinghua.edu.cn/packages/90/41/4767ff64e422734487a06384a66e62615b1f5cf9cf3b23295e22d3ecf711/email_validator-2.1.0-py3-none-any.whl (32 kB)
Collecting dnspython>=2.0.0
  Using cached https://pypi.tuna.tsinghua.edu.cn/packages/12/86/d305e87555430ff4630d729420d97dece3b16efcbf2b7d7e974d11b0d86c/dnspython-2.3.0-py3-none-any.whl (283 kB)
Requirement already satisfied: idna>=2.0.0 in ./anaconda3/envs/py37/lib/python3.7/site-packages (from email-validator) (3.4)
Installing collected packages: dnspython, email-validator
Successfully installed dnspython-2.3.0 email-validator-2.1.0
❯ python3
Python 3.7.16 (default, Jan 17 2023, 22:20:44) 
[GCC 11.2.0] :: Anaconda, Inc. on linux
Type "help", "copyright", "credits" or "license" for more information.
>>> import email_validator
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/home/tianwei/anaconda3/envs/py37/lib/python3.7/site-packages/email_validator/__init__.py", line 6, in <module>
    from .validate_email import validate_email
  File "/home/tianwei/anaconda3/envs/py37/lib/python3.7/site-packages/email_validator/validate_email.py", line 10
    /,  # prior arguments are positional-only
    ^
SyntaxError: invalid syntax
>>> 
```

In python3.7 environment, `2.1.0` version can still be installed successfully.