### PR TITLE
Update __init__.py

### DIFF
--- a/email_validator/__init__.py
+++ b/email_validator/__init__.py
@@ -1,8 +1,8 @@
 # -*- coding: utf-8 -*-
 
 # Export the main method, helper methods, and the public data types.
-from .exceptions_types import ValidatedEmail, EmailNotValidError, \
-                              EmailSyntaxError, EmailUndeliverableError
+from .exceptions_types import (ValidatedEmail, EmailNotValidError,
+                              EmailSyntaxError, EmailUndeliverableError)
 from .validate_email import validate_email
 from .version import __version__
 


### PR DESCRIPTION
Fix to avoid the following error, from using  fastapi[all] in requirements .
SyntaxError: invalid syntax
 /, # prior arguments are positional-only
 File "/usr/local/lib/python3.7/site-packages/email_validator/validate_email.py", line 10
 from .validate_email import validate_email
 File "/usr/local/lib/python3.7/site-packages/email_validator/__init__.py", line 6, in <module>
 import email_validator
 File "/usr/local/lib/python3.7/site-packages/fastapi/openapi/models.py", line 18, in <module>
 from fastapi.openapi.models import Example
 File "/usr/local/lib/python3.7/site-packages/fastapi/params.py", line 5, in <module>
 from fastapi import params
 File "/usr/local/lib/python3.7/site-packages/fastapi/routing.py", line 22, in <module>
 from fastapi import routing
 File "/usr/local/lib/python3.7/site-packages/fastapi/applications.py", line 16, in <module>
 from .applications import FastAPI as FastAPI
 File "/usr/local/lib/python3.7/site-packages/fastapi/__init__.py", line 7, in <module>
 from fastapi import FastAPI