### PR TITLE
Fix a few minor typos

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -77,7 +77,7 @@ Version 1.2.1 (May 1, 2022)
 * example.com/net/org are removed from the special-use reserved domain names list so that they do not raise exceptions if check_deliverability is off.
 * Improved README.
 
-Verison 1.2.0 (April 24, 2022)
+Version 1.2.0 (April 24, 2022)
 ------------------------------
 
 * Reject domains with NULL MX records (when deliverability checks

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ users by their email address like on a registration form.
 Key features:
 
 * Checks that an email address has the correct syntax --- great for
-  email-based registration/login forms or validing data.
+  email-based registration/login forms or validating data.
 * Gives friendly English error messages when validation fails that you
   can display to end-users.
 * Checks deliverability (optional): Does the domain name resolve?

--- a/email_validator/__main__.py
+++ b/email_validator/__main__.py
@@ -38,7 +38,7 @@ def main(dns_resolver: Optional[_Resolver] = None) -> None:
             options[varname.lower()] = float(os.environ[varname])
 
     if len(sys.argv) == 1:
-        # Validate the email addresses pased line-by-line on STDIN.
+        # Validate the email addresses passed line-by-line on STDIN.
         dns_resolver = dns_resolver or caching_resolver()
         for line in sys.stdin:
             email = line.strip()

--- a/email_validator/syntax.py
+++ b/email_validator/syntax.py
@@ -57,7 +57,7 @@ def split_email(email: str) -> Tuple[Optional[str], str, str, bool]:
         for i, c in enumerate(text):
             # < plus U+0338 (Combining Long Solidus Overlay) normalizes to
             # ≮ U+226E (Not Less-Than), and  it would be confusing to treat
-            # the < as the start of "<email>" syntax in that case. Liekwise,
+            # the < as the start of "<email>" syntax in that case. Likewise,
             # if anything combines with an @ or ", we should probably not
             # treat it as a special character.
             if unicodedata.normalize("NFC", text[i:])[0] != c:
@@ -642,7 +642,7 @@ def validate_email_length(addrinfo: ValidatedEmail) -> None:
     #    form is checked first because it is the original input.
     # 2) The normalized email address. We perform Unicode NFC normalization of
     #    the local part, we normalize the domain to internationalized characters
-    #    (if originaly IDNA ASCII) which also includes Unicode normalization,
+    #    (if originally IDNA ASCII) which also includes Unicode normalization,
     #    and we may remove quotes in quoted local parts. We recommend that
     #    callers use this string, so it must be valid.
     # 3) The email address with the IDNA ASCII representation of the domain


### PR DESCRIPTION
After I noticed the typo in README.md, I went hunting for others using `codespell` and fixed everything I found.