### PR TITLE
Support ALLOW_DISPLAY_NAME and ALLOW_EMPTY_LOCAL in the CLI

### DIFF
--- a/email_validator/__init__.py
+++ b/email_validator/__init__.py
@@ -27,6 +27,7 @@ else:
 # Default values for keyword arguments.
 
 ALLOW_SMTPUTF8 = True
+ALLOW_EMPTY_LOCAL = False
 ALLOW_QUOTED_LOCAL = False
 ALLOW_DOMAIN_LITERAL = False
 ALLOW_DISPLAY_NAME = False

--- a/email_validator/__main__.py
+++ b/email_validator/__main__.py
@@ -29,7 +29,7 @@ def main(dns_resolver: Optional[_Resolver] = None) -> None:
 
     # Set options from environment variables.
     options: Dict[str, Any] = {}
-    for varname in ('ALLOW_SMTPUTF8', 'ALLOW_QUOTED_LOCAL', 'ALLOW_DOMAIN_LITERAL',
+    for varname in ('ALLOW_SMTPUTF8', 'ALLOW_EMPTY_LOCAL', 'ALLOW_QUOTED_LOCAL', 'ALLOW_DOMAIN_LITERAL',
                     'ALLOW_DISPLAY_NAME',
                     'GLOBALLY_DELIVERABLE', 'CHECK_DELIVERABILITY', 'TEST_ENVIRONMENT'):
         if varname in os.environ:

--- a/email_validator/__main__.py
+++ b/email_validator/__main__.py
@@ -30,6 +30,7 @@ def main(dns_resolver: Optional[_Resolver] = None) -> None:
     # Set options from environment variables.
     options: Dict[str, Any] = {}
     for varname in ('ALLOW_SMTPUTF8', 'ALLOW_QUOTED_LOCAL', 'ALLOW_DOMAIN_LITERAL',
+                    'ALLOW_DISPLAY_NAME',
                     'GLOBALLY_DELIVERABLE', 'CHECK_DELIVERABILITY', 'TEST_ENVIRONMENT'):
         if varname in os.environ:
             options[varname.lower()] = bool(os.environ[varname])

--- a/email_validator/validate_email.py
+++ b/email_validator/validate_email.py
@@ -17,7 +17,7 @@ def validate_email(
     /,  # prior arguments are positional-only
     *,  # subsequent arguments are keyword-only
     allow_smtputf8: Optional[bool] = None,
-    allow_empty_local: bool = False,
+    allow_empty_local: Optional[bool] = None,
     allow_quoted_local: Optional[bool] = None,
     allow_domain_literal: Optional[bool] = None,
     allow_display_name: Optional[bool] = None,
@@ -34,10 +34,12 @@ def validate_email(
     """
 
     # Fill in default values of arguments.
-    from . import ALLOW_SMTPUTF8, ALLOW_QUOTED_LOCAL, ALLOW_DOMAIN_LITERAL, ALLOW_DISPLAY_NAME, \
+    from . import ALLOW_SMTPUTF8, ALLOW_EMPTY_LOCAL, ALLOW_QUOTED_LOCAL, ALLOW_DOMAIN_LITERAL, ALLOW_DISPLAY_NAME, \
         GLOBALLY_DELIVERABLE, CHECK_DELIVERABILITY, TEST_ENVIRONMENT, DEFAULT_TIMEOUT
     if allow_smtputf8 is None:
         allow_smtputf8 = ALLOW_SMTPUTF8
+    if allow_empty_local is None:
+        allow_empty_local = ALLOW_EMPTY_LOCAL
     if allow_quoted_local is None:
         allow_quoted_local = ALLOW_QUOTED_LOCAL
     if allow_domain_literal is None:


### PR DESCRIPTION
Expose the `allow_display_name` and `allow_empty_local` keyword argument to the CLI tool. Adjust the `allow_empty_local` keyword to be an `Optional[bool]`, like similar keywords.