### PR TITLE
Correctly handle None, add tests for other invalid types

### DIFF
--- a/email_validator/validate_email.py
+++ b/email_validator/validate_email.py
@@ -62,7 +62,7 @@ def validate_email(
     if not isinstance(email, str):
         try:
             email = email.decode("ascii")
-        except ValueError as e:
+        except (AttributeError, ValueError) as e:
             raise EmailSyntaxError("The email address is not valid ASCII.") from e
 
     # Split the address into the display name (or None), the local part

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -65,3 +65,17 @@ def test_deprecation() -> None:
     valid_email = validate_email(input_email, check_deliverability=False)
     with pytest.deprecated_call():
         assert valid_email.email is not None
+
+
+@pytest.mark.parametrize('invalid_email', [
+    None,
+    12345,
+    [],
+    {},
+    lambda x: x,
+    # I believe this is a valid email address, but it's not valid ASCII
+    b'\xd0\xba\xd0\xb2\xd1\x96\xd1\x82\xd0\xbe\xd1\x87\xd0\xba\xd0\xb0@\xd0\xbf\xd0\xbe\xd1\x88\xd1\x82\xd0\xb0.test'
+])
+def test_invalid_type(invalid_email) -> None:
+    with pytest.raises(EmailSyntaxError, match="The email address is not valid ASCII"):
+        validate_email(invalid_email, check_deliverability=False)


### PR DESCRIPTION
### Why I made this PR

Hello! It seems calling `.decode` on `None` raises an `AttributeError` - which is unfortunately not handled by this library. Calling `validate_email(None)` generates this exception:

> AttributeError: 'NoneType' object has no attribute 'decode'

### What is included in the PR

I've added a catch for the `AttributeError` and some additional tests for invalid types.

Thank you for maintaining this library!