### PR TITLE
fix: preserve original email string for quoted local parts with backslash escapes

### DIFF
--- a/email_validator/validate_email.py
+++ b/email_validator/validate_email.py
@@ -1,4 +1,5 @@
 from typing import Optional, TYPE_CHECKING
+import re
 import unicodedata
 
 from .exceptions import EmailSyntaxError
@@ -90,9 +91,16 @@ def validate_email(
 
     # Collect return values in this instance.
     ret = ValidatedEmail()
-    ret.original = ((local_part if not is_quoted_local_part
-                    else ('"' + local_part + '"'))
-                    + "@" + domain_part)  # drop the display name, if any, for email length tests at the end
+    # Store the original email address without any display name, preserving
+    # the original form (including backslash escapes in quoted local parts).
+    # When no display name is present, use the original email string directly.
+    # When a display name is present, extract just the address from the angle
+    # brackets so that email length checks use the address-only form.
+    if display_name is None:
+        ret.original = email
+    else:
+        m = re.search(r'<(.+)>', email)
+        ret.original = m.group(1) if m else email
     ret.display_name = display_name
 
     # Validate the email address's local part syntax and get a normalized form.


### PR DESCRIPTION
## Bug

When `validate_email` is called with a quoted local part that contains backslash-escaped characters — for example `"test\"foo"@example.com` — the `original` field on the returned `ValidatedEmail` object is built incorrectly.

The code reconstructs `ret.original` by re-quoting the already-unescaped `local_part`. Since `split_email()` returns the local part with escapes removed (i.e. `test"foo`), re-wrapping it in quotes produces `"test"foo"@example.com` — an invalid, malformed string that is also one character shorter than the actual input.

```python
from email_validator import validate_email

email = '"test\\"foo"@example.com'
r = validate_email(email, check_deliverability=False, allow_quoted_local=True)

# Before fix:
# r.original == '"test"foo"@example.com'  ← wrong (invalid, missing backslash)
# r.normalized == '"test\\"foo"@example.com'  ← correct

# After fix:
# r.original == '"test\\"foo"@example.com'  ← correct (same as input)
# r.normalized == '"test\\"foo"@example.com'  ← correct
```

The documented contract (`ValidatedEmail.original`: *"The email address that was passed to `validate_email`."*) is violated. Additionally, the incorrect shorter string is used for email length checks (`validate_email_length`), which could allow emails that are actually over the 254-byte limit to pass when they contain backslash-escaped characters in a quoted local part.

## Fix

When no display name is present, use the original `email` argument directly — no reconstruction needed. When a display name is present (e.g. `"John" <addr@domain>`), extract the address from inside the angle brackets to preserve the existing behavior of stripping the display name for email length checks.

All 288 existing syntax tests pass.

---

This pull request was prepared with the assistance of AI, under my direction and review.